### PR TITLE
Add High Sierra bottles (made manually)

### DIFF
--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -1,8 +1,15 @@
 class Libbuddy < Formula
-  desc "binary decision diagram library"
+  desc "Binary decision diagram library"
   homepage "https://sourceforge.net/projects/buddy/"
   url "https://downloads.sourceforge.net/project/buddy/buddy/BuDDy%202.4/buddy-2.4.tar.gz"
   sha256 "d3df80a6a669d9ae408cb46012ff17bd33d855529d20f3a7e563d0d913358836"
+
+  bottle do
+    root_url "https://dl.bintray.com/katriel/tamarin-prover"
+    cellar :any
+    rebuild 1
+    sha256 "5c150e653aeb36ce34381f24137c963419a169e665cdfa5e6f15495923beb694" => :high_sierra
+  end
 
   bottle do
     cellar :any

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -6,6 +6,13 @@ class Maude < Formula
   revision 1
 
   bottle do
+    root_url "https://dl.bintray.com/katriel/tamarin-prover"
+    cellar :any
+    rebuild 1
+    sha256 "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5" => :high_sierra
+  end
+
+  bottle do
     cellar :any
     sha256 "952d23e1f143bfb62e21fb4b0e1b440dcfc431cc7250f458c4c1ecf7234fea5e" => :sierra
     sha256 "042a617f84cacfdd0d8f441fcf1209fe6bef76483b0cf848bded5dc378f82bc6" => :el_capitan

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -12,6 +12,12 @@ class TamarinProver < Formula
   depends_on "graphviz"
   depends_on :macos => :mountain_lion
 
+  bottle do
+    root_url "https://dl.bintray.com/katriel/tamarin-prover"
+    cellar :any_skip_relocation
+    sha256 "c530417ab4ce6901fc08dd198793ddd281bbad7892c61fe6d82da71e21e88f12" => :high_sierra
+  end
+
   # doi "10.1109/CSF.2012.25"
   # tag "security"
 


### PR DESCRIPTION
I'm hosting the bottles on bintray using their open-source account; this is the same platform that hosts homebrew's own bottles.  I built them manually on my High Sierra mac desktop with (mutatis mutandis)

```
brew install --build-bottle tamarin-prover/tap/tamarin-prover
brew bottle tamarin-prover
```

This makes a file in the current directory which I then uploaded to bintray and added to the formulae.