### PR TITLE
Update to 1.4.0

### DIFF
--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -5,7 +5,7 @@ class Libbuddy < Formula
   sha256 "d3df80a6a669d9ae408cb46012ff17bd33d855529d20f3a7e563d0d913358836"
 
   bottle do
-    root_url "https://dl.bintray.com/katriel/tamarin-prover"
+    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
     cellar :any
     rebuild 1
     sha256 "5c150e653aeb36ce34381f24137c963419a169e665cdfa5e6f15495923beb694" => :high_sierra

--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -5,7 +5,7 @@ class Libbuddy < Formula
   sha256 "d3df80a6a669d9ae408cb46012ff17bd33d855529d20f3a7e563d0d913358836"
 
   bottle do
-    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
+    root_url "https://dl.bintray.com/tamarin-prover-org/libbuddy"
     cellar :any
     rebuild 1
     sha256 "5c150e653aeb36ce34381f24137c963419a169e665cdfa5e6f15495923beb694" => :high_sierra

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -6,7 +6,7 @@ class Maude < Formula
   revision 1
 
   bottle do
-    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
+    root_url "https://dl.bintray.com/tamarin-prover-org/maude"
     cellar :any
     rebuild 1
     sha256 "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5" => :high_sierra

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -6,7 +6,7 @@ class Maude < Formula
   revision 1
 
   bottle do
-    root_url "https://dl.bintray.com/katriel/tamarin-prover"
+    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
     cellar :any
     rebuild 1
     sha256 "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5" => :high_sierra

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -1,21 +1,21 @@
 class TamarinProver < Formula
   desc "Automated security protocol verification tool"
   homepage "https://tamarin-prover.github.io/"
-  url "https://github.com/tamarin-prover/tamarin-prover/archive/1.2.3.tar.gz"
-  sha256 "9b637460cbadd826d8a2cdb324b660b47c6a27ff4df32e820925018c16f67796"
+  url "https://github.com/tamarin-prover/tamarin-prover/archive/1.4.0.tar.gz"
+  sha256 "e92ddcc9ddc9b115eb7605606acbc182feb3bb0012039d5c983d400cf0165f8d"
   head "https://github.com/tamarin-prover/tamarin-prover.git", :branch => "develop"
 
   depends_on "haskell-stack" => :build
-  depends_on "ocaml" => :build
   depends_on "zlib" => :build unless OS.mac?
   depends_on "maude"
   depends_on "graphviz"
+  depends_on "ocaml" => :build
   depends_on :macos => :mountain_lion
 
   bottle do
-    root_url "https://dl.bintray.com/katriel/tamarin-prover"
+    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
     cellar :any_skip_relocation
-    sha256 "c530417ab4ce6901fc08dd198793ddd281bbad7892c61fe6d82da71e21e88f12" => :high_sierra
+    # Looking at docs might be able to use :sierra_or_later
   end
 
   # doi "10.1109/CSF.2012.25"
@@ -28,6 +28,9 @@ class TamarinProver < Formula
     args = []
     args << "--extra-include-dirs=#{Formula["zlib"].include}" << "--extra-lib-dirs=#{Formula["zlib"].lib}" unless OS.mac?
     system "stack", "-j#{jobs}", *args, "install", "--flag", "tamarin-prover:threaded"
+
+    # `ocaml` building under linuxbrew needs to be single core.
+    ENV.deparallelize
     system "make", "sapic"
 
     bin.install Dir[".brew_home/.local/bin/*"]


### PR DESCRIPTION
These commits include the following changes:

- Update TAMARIN to 1.4.0
- Enables `ENV.deparallelize` when building SAPIC only
- All Formulas now point to `/tamarin-prover-org/*`