### PR TITLE
Release 1.4.1

### DIFF
--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -6,9 +6,9 @@ class Maude < Formula
   revision 1
 
   bottle do
-    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover/maude"
+    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
     cellar :any
-    rebuild 2
+    sha256 "120e8e9c8a83bfa0787b2e0b8f3ae798c18efd5db99e55a6a6ed3f37b56b820b" => :mojave
     sha256 "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5" => :high_sierra
     sha256 "952d23e1f143bfb62e21fb4b0e1b440dcfc431cc7250f458c4c1ecf7234fea5e" => :sierra
     sha256 "042a617f84cacfdd0d8f441fcf1209fe6bef76483b0cf848bded5dc378f82bc6" => :el_capitan

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -17,6 +17,7 @@ class TamarinProver < Formula
     cellar :any_skip_relocation
     # Looking at docs might be able to use :sierra_or_later
     sha256 "694ee78a3828a6f0f26902d49902abc8d46ad2877870a2bc07bfdeb156b9f509" => :high_sierra
+    sha256 "ff644b9cde0c9d789770dffe55e5204d3ae9678565da5a529aa758ea202c1d14" => :mojave
   end
 
   # doi "10.1109/CSF.2012.25"

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -1,8 +1,8 @@
 class TamarinProver < Formula
   desc "Automated security protocol verification tool"
   homepage "https://tamarin-prover.github.io/"
-  url "https://github.com/tamarin-prover/tamarin-prover/archive/1.4.0.tar.gz"
-  sha256 "e92ddcc9ddc9b115eb7605606acbc182feb3bb0012039d5c983d400cf0165f8d"
+  url "https://github.com/tamarin-prover/tamarin-prover/archive/1.4.1.tar.gz"
+  sha256 "d0e95d738060d44bcce698877cc56c34ec61de1ca73d50d5d8a7a35ade990400"
   head "https://github.com/tamarin-prover/tamarin-prover.git", :branch => "develop"
 
   depends_on "haskell-stack" => :build
@@ -16,9 +16,7 @@ class TamarinProver < Formula
     root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
     cellar :any_skip_relocation
     # Looking at docs might be able to use :sierra_or_later
-    sha256 "c4e2c37ee3823670e6fcff47e48722b0f9406585b6a059a40251b2cd214f7513" => :mojave
-    sha256 "da3bba52d6f0ff69b6d4a818044d02473ca494051272cd628b4418cb361af59e" => :high_sierra
-    sha256 "1571c86decfb34621b20fe3a60bd675b62b34699c59d83ae30dc91bf47d2738c" => :x86_64_linux
+    sha256 "694ee78a3828a6f0f26902d49902abc8d46ad2877870a2bc07bfdeb156b9f509" => :high_sierra
   end
 
   # doi "10.1109/CSF.2012.25"


### PR DESCRIPTION
This releases 1.4.1, with only a high sierra bottle for the moment (works on mojave as well). Building other bottles is in progress.

I also fixed the maude formula which was previously causing it to be rebuilt from source on everything other than linux (because of a versioning issue). It should now get bottles correctly on every platform, I think.