### PR TITLE
Updated readme with better bottling instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ brew install tamarin-prover/tap/tamarin-prover
 Homebrew formulae can include compiled binaries, which it calls "bottles". To build a new bottle (perhaps for a new operating system or Tamarin release):
 
 1. `brew install --build-bottle tamarin-prover/tap/tamarin-prover`
-1. `brew bottle tamarin-prover` and note the line of output it gives you with the bottle SHA and tag
-1. Give the resulting file (e.g. `tamarin-prover-1.2.3.tar.gz`) to Katriel and ask him to upload it to Bintray
+1. `brew bottle tamarin-prover --keep-old --root-url=https://dl.bintray.com/tamarin-prover-org/tamarin-prover` and note the line of output it gives you with the bottle SHA and tag
+1. Rename the bottle to use a single hyphen (e.g. `tamarin-prover--1.4.1.mojave.bottle.tar.gz` to `tamarin-prover-1.4.1.mojave.bottle.tar.gz`)
+1. Give the resulting file to Katriel and ask him to upload it to Bintray
 1. Update the `tamarin-prover` formula with the bottle SHA and tag, in the bottle section with the custom Bintray URL
 
 New installs will then use this bottle.


### PR DESCRIPTION
Without the `--keep-old` command line flag (and the `--root-url` flag required to use it), building a new bottle would increment the `rebuild version` of the formula, with the assumption that the new bottle is for newer version of the build that supersedes the previous bottles (even if they are for a different platform). In the previous 1.4.0 release this caused some issues: the linux bottle was built after the other bottles, and ended up increasing the `rebuild version` in the formula, which made all of the existing bottles out of date.

This can always be fixed manually by whoever uploads the bottle to bintray but better if it's just generated with the same version to begin with.