### PR TITLE
Add big sur bottle

### DIFF
--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -15,7 +15,8 @@ class TamarinProver < Formula
   bottle do
     root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
     cellar :any_skip_relocation
-    # Looking at docs might be able to use :sierra_or_later
+    # Looking at docs might be able to use :sierra_or_later?
+    sha256 "75f6fd3fd37c2428ecf6b28a49906ecb3dfad48bdebed857fd72d424dd2f47e7" => :big_sur
     sha256 "37af72ed0cb070682c278a7e0298c3a17f5938e3a86e38b31a56900e50798717" => :catalina
     sha256 "c96a2ad6f0cb8eb29a51b1c33896732185cd770876fc3ccb16710f0889a96a9f" => :x86_64_linux
   end


### PR DESCRIPTION
Bottle has also been uploaded to bintray. This may or may not resolve `brew install tamarin-prover` on M1 macs.