### PR TITLE
Fix deprecated formula style via brew style --fix

### DIFF
--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -6,14 +6,13 @@ class Libbuddy < Formula
 
   bottle do
     root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
-    cellar :any_skip_relocation
     rebuild 3
-    sha256 "be9577ed9a01c80b48f459a08c60e6a27813a5131e5a735855a41205dffc00a3" => :catalina
-    sha256 "5c150e653aeb36ce34381f24137c963419a169e665cdfa5e6f15495923beb694" => :high_sierra
-    sha256 "5dc396c196d46646102d10c5d3ff32d8b37249cac78af2595417e6474494453b" => :el_capitan
-    sha256 "451c34f54e575578a3b3cfaad5e5a860f012317ff32053097c6132bba60a7da9" => :yosemite
-    sha256 "f4a66068fc8b53b557e3c9f6be57574c1711aedd91e1f18e2b6c5111b62fdbe7" => :mavericks
-    sha256 "0807d5706dc37213dbc466b06819fc1b93d710c3543b92eec3c07e7c4fc317d5" => :x86_64_linux
+    sha256 cellar: :any_skip_relocation, catalina:     "be9577ed9a01c80b48f459a08c60e6a27813a5131e5a735855a41205dffc00a3"
+    sha256 cellar: :any_skip_relocation, high_sierra:  "5c150e653aeb36ce34381f24137c963419a169e665cdfa5e6f15495923beb694"
+    sha256 cellar: :any_skip_relocation, el_capitan:   "5dc396c196d46646102d10c5d3ff32d8b37249cac78af2595417e6474494453b"
+    sha256 cellar: :any_skip_relocation, yosemite:     "451c34f54e575578a3b3cfaad5e5a860f012317ff32053097c6132bba60a7da9"
+    sha256 cellar: :any_skip_relocation, mavericks:    "f4a66068fc8b53b557e3c9f6be57574c1711aedd91e1f18e2b6c5111b62fdbe7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "0807d5706dc37213dbc466b06819fc1b93d710c3543b92eec3c07e7c4fc317d5"
   end
 
   def install

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -1,5 +1,5 @@
 class Maude < Formula
-  desc "reflective language for equational and rewriting logic specification"
+  desc "Reflective language for equational and rewriting logic specification"
   homepage "http://maude.cs.illinois.edu"
   url "http://maude.cs.illinois.edu/w/images/d/d8/Maude-2.7.1.tar.gz"
   sha256 "b1887c7fa75e85a1526467727242f77b5ec7cd6a5dfa4ceb686b6f545bb1534b"
@@ -7,13 +7,12 @@ class Maude < Formula
 
   bottle do
     root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
-    cellar :any
-    sha256 "120e8e9c8a83bfa0787b2e0b8f3ae798c18efd5db99e55a6a6ed3f37b56b820b" => :mojave
-    sha256 "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5" => :high_sierra
-    sha256 "952d23e1f143bfb62e21fb4b0e1b440dcfc431cc7250f458c4c1ecf7234fea5e" => :sierra
-    sha256 "042a617f84cacfdd0d8f441fcf1209fe6bef76483b0cf848bded5dc378f82bc6" => :el_capitan
-    sha256 "8bb72b9a8f9097656ffb4f70f7b7addb2ba2a888134af1bd96b488340d25aadc" => :yosemite
-    sha256 "e341985f51abe73a4516690daf2b5bf384286b2f48414b79108cc9933187e014" => :x86_64_linux
+    sha256 cellar: :any, mojave:       "120e8e9c8a83bfa0787b2e0b8f3ae798c18efd5db99e55a6a6ed3f37b56b820b"
+    sha256 cellar: :any, high_sierra:  "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5"
+    sha256 cellar: :any, sierra:       "952d23e1f143bfb62e21fb4b0e1b440dcfc431cc7250f458c4c1ecf7234fea5e"
+    sha256 cellar: :any, el_capitan:   "042a617f84cacfdd0d8f441fcf1209fe6bef76483b0cf848bded5dc378f82bc6"
+    sha256 cellar: :any, yosemite:     "8bb72b9a8f9097656ffb4f70f7b7addb2ba2a888134af1bd96b488340d25aadc"
+    sha256 cellar: :any, x86_64_linux: "e341985f51abe73a4516690daf2b5bf384286b2f48414b79108cc9933187e014"
   end
 
   depends_on "gmp"
@@ -31,7 +30,7 @@ class Maude < Formula
                           "--prefix=#{libexec}",
                           "--without-cvc4"
     system "make", "install"
-    (bin/"maude").write_env_script libexec/"bin/maude", :MAUDE_LIB => libexec/"share"
+    (bin/"maude").write_env_script libexec/"bin/maude", MAUDE_LIB: libexec/"share"
   end
 
   test do

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -3,22 +3,21 @@ class TamarinProver < Formula
   homepage "https://tamarin-prover.github.io/"
   url "https://github.com/tamarin-prover/tamarin-prover/archive/1.6.0.tar.gz"
   sha256 "b643fbcf5cd604fe2284e3de870140aac6d03b14651b61d792002e879aea6b45"
-  head "https://github.com/tamarin-prover/tamarin-prover.git", :branch => "develop"
+  head "https://github.com/tamarin-prover/tamarin-prover.git", branch: "develop"
+
+  bottle do
+    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
+    # Looking at docs might be able to use :sierra_or_later
+    sha256 cellar: :any_skip_relocation, catalina:     "37af72ed0cb070682c278a7e0298c3a17f5938e3a86e38b31a56900e50798717"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "c96a2ad6f0cb8eb29a51b1c33896732185cd770876fc3ccb16710f0889a96a9f"
+  end
 
   depends_on "haskell-stack" => :build
   depends_on "zlib" => :build unless OS.mac?
   depends_on "ocaml" => :build
   depends_on "graphviz"
-  depends_on :macos => :yosemite
+  depends_on macos: :yosemite
   depends_on "maude"
-
-  bottle do
-    root_url "https://dl.bintray.com/tamarin-prover-org/tamarin-prover"
-    cellar :any_skip_relocation
-    # Looking at docs might be able to use :sierra_or_later
-    sha256 "37af72ed0cb070682c278a7e0298c3a17f5938e3a86e38b31a56900e50798717" => :catalina
-    sha256 "c96a2ad6f0cb8eb29a51b1c33896732185cd770876fc3ccb16710f0889a96a9f" => :x86_64_linux
-  end
 
   # doi "10.1109/CSF.2012.25"
   # tag "security"
@@ -28,7 +27,9 @@ class TamarinProver < Formula
     jobs = ENV.make_jobs
     system "stack", "-j#{jobs}", "setup"
     args = []
-    args << "--extra-include-dirs=#{Formula["zlib"].include}" << "--extra-lib-dirs=#{Formula["zlib"].lib}" unless OS.mac?
+    unless OS.mac?
+      args << "--extra-include-dirs=#{Formula["zlib"].include}" << "--extra-lib-dirs=#{Formula["zlib"].lib}"
+    end
     system "stack", "-j#{jobs}", *args, "install", "--flag", "tamarin-prover:threaded"
 
     # `ocaml` building under linuxbrew needs to be single core.


### PR DESCRIPTION
Homebrew deprecated the old style of hash specification we were using, so running a brew upgrade on our current tap results in it spitting out a bunch of warnings, e.g.

```
Warning: Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the tamarin-prover/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/tamarin-prover/homebrew-tap/Formula/libbuddy.rb:9

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the tamarin-prover/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/tamarin-prover/homebrew-tap/Formula/libbuddy.rb:11

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the tamarin-prover/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/tamarin-prover/homebrew-tap/Formula/libbuddy.rb:12

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the tamarin-prover/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/tamarin-prover/homebrew-tap/Formula/libbuddy.rb:13

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the tamarin-prover/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/tamarin-prover/homebrew-tap/Formula/libbuddy.rb:14

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the tamarin-prover/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/tamarin-prover/homebrew-tap/Formula/libbuddy.rb:15

Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the tamarin-prover/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/tamarin-prover/homebrew-tap/Formula/libbuddy.rb:16
```

This PR is just the result of running `brew style --fix` on each of the formulas, which reports that it has successfully corrected all issues.

