### PR TITLE
Move binary dependencies

### DIFF
--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -5,7 +5,7 @@ class Libbuddy < Formula
   sha256 "d3df80a6a669d9ae408cb46012ff17bd33d855529d20f3a7e563d0d913358836"
 
   bottle do
-    root_url "https://github.com/tamarin-prover/tamarin-prover/releases/download/1.6.0"
+    root_url "https://github.com/tamarin-prover/binaries/blob/main/dependencies"
     rebuild 3
     sha256 cellar: :any_skip_relocation, catalina:     "be9577ed9a01c80b48f459a08c60e6a27813a5131e5a735855a41205dffc00a3"
     sha256 cellar: :any_skip_relocation, high_sierra:  "5c150e653aeb36ce34381f24137c963419a169e665cdfa5e6f15495923beb694"

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -6,7 +6,7 @@ class Maude < Formula
   revision 1
 
   bottle do
-    root_url "https://github.com/tamarin-prover/tamarin-prover/releases/download/1.6.0"
+    root_url "https://github.com/tamarin-prover/binaries/blob/main/dependencies"
     sha256 cellar: :any, mojave:       "120e8e9c8a83bfa0787b2e0b8f3ae798c18efd5db99e55a6a6ed3f37b56b820b"
     sha256 cellar: :any, high_sierra:  "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5"
     sha256 cellar: :any, sierra:       "952d23e1f143bfb62e21fb4b0e1b440dcfc431cc7250f458c4c1ecf7234fea5e"


### PR DESCRIPTION
Maude and Libbuddy are now [here](https://github.com/tamarin-prover/binaries/tree/main/dependencies).
The root_url in both maude and libbuddy formulas has been changed to go along with the new location of the binaries.
Notice that Tamarin path hasn't changed, only the dependencies have been moved to a new location.
