### PR TITLE
Add maude bottle for Catalina, update bottling instructions

### DIFF
--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -7,6 +7,7 @@ class Maude < Formula
 
   bottle do
     root_url "https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies"
+    sha256 cellar: :any, catalina:     "92c92b1d2e4532f35311b8a53f3ef73760823625e656c3dce42b2520ab3de14d"
     sha256 cellar: :any, mojave:       "120e8e9c8a83bfa0787b2e0b8f3ae798c18efd5db99e55a6a6ed3f37b56b820b"
     sha256 cellar: :any, high_sierra:  "747d2709c2e8db7b5aaca5b0ca8e200a596052606a31bb970b3823524a98e2b5"
     sha256 cellar: :any, sierra:       "952d23e1f143bfb62e21fb4b0e1b440dcfc431cc7250f458c4c1ecf7234fea5e"

--- a/README.md
+++ b/README.md
@@ -10,13 +10,22 @@ Install Homebrew and run
 brew install tamarin-prover/tap/tamarin-prover
 ```
 
-## Building bottles
+## Building bottles for Tamarin
 Homebrew formulae can include compiled binaries, which it calls "bottles". To build a new bottle (perhaps for a new operating system or Tamarin release):
 
 1. `brew install --build-bottle tamarin-prover/tap/tamarin-prover`
-2. `brew bottle tamarin-prover --keep-old --root-url=https://github.com/tamarin-prover/tamarin-prover/releases/download/VERSION` where VERSION is the current release, e.g, 1.6.0, and note the output it gives you with the bottle SHA and tag
+2. `brew bottle tamarin-prover --keep-old --root-url=https://github.com/tamarin-prover/tamarin-prover/releases/download/VERSION` where VERSION is the current release, e.g, 1.6.0, and note the output it gives you with the bottle SHA and tag,
 3. Rename the bottle to use a single hyphen (e.g., `tamarin-prover--1.4.1.mojave.bottle.tar.gz` to `tamarin-prover-1.4.1.mojave.bottle.tar.gz`). Homebrew should give you the relevant output on the command line to update in the `tamarin-prover.rb` formula. If not, on Linux, run sha256sum on the renamed file, and use the result to replace the bottle hash from previous item. On macOS, use `shasum -a 256 <filename>`.
-4. Submit a separate pull request for https://github.com/tamarin-prover/binaries/ containing the new binaries.
+4. Add binaries to the GitHub release.
 5. Update the `tamarin-prover.rb` formula with the bottle SHA and tag, in the bottle section.
 
 New installs will then use this bottle.
+
+## Building bottles for dependencies
+To build a new bottle (perhaps for a new operating system or Maude/libbuddy release):
+
+1. `brew install --build-bottle tamarin-prover/tap/maude` or `brew install --build-bottle tamarin-prover/tap/libbuddy`
+2. `brew bottle maude --keep-old --root-url=https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies` or `brew bottle lib buddy --keep-old --root-url=https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies`, and note the output it gives you with the bottle SHA and tag,
+3. Rename the bottle to use a single hyphen. Homebrew should give you the relevant output on the command line to update in the `maude.rb` or `libbuddy.rb` formula. If not, on Linux, run sha256sum on the renamed file, and use the result to replace the bottle hash from previous item. On macOS, use `shasum -a 256 <filename>`.
+4. Submit a separate pull request for https://github.com/tamarin-prover/binaries/ containing the new binaries for maude or lib buddy.
+5. Update the `maude.rb` or `libbuddy.rb` formula with the bottle SHA and tag, in the bottle section.


### PR DESCRIPTION
Catalina was previously using an old bottle, this adds a special bottle for Catalina. Also updated README with correct root-url, and added further explanation on how to bottle dependencies.