### PR TITLE
Fixes for building libbuddy and maude on m1, and corresponding bottles

### DIFF
--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -13,10 +13,13 @@ class Libbuddy < Formula
   end
 
   def install
+    if Hardware::CPU.arm? && OS.mac?
+      system "echo 'echo arm-apple-darwin' > tools/config.sub"
+    end
     system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}"
     system "make", "install"
   end
 

--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -10,6 +10,7 @@ class Libbuddy < Formula
     sha256 cellar: :any_skip_relocation, big_sur:      "2d2c92c55832c9f6ba160cc9154542779a63ab111bb8bc668f295e776dc1ab9a"
     sha256 cellar: :any_skip_relocation, catalina:     "3cab96ab2fe4506669abd447bf5185e789ab0ea2a40536ff61b0b734f167f5a0"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "0807d5706dc37213dbc466b06819fc1b93d710c3543b92eec3c07e7c4fc317d5"
+    sha256 cellar: :any, arm64_monterey: "a1d72f509f29a606e8ed0ca3fa0ecbf39fcbfba0ec2375a101e23ab79f2c5162"
   end
 
   def install

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -25,6 +25,9 @@ class Maude < Formula
   depends_on "bison" unless OS.mac?
 
   def install
+    if Hardware::CPU.arm? && OS.mac?
+      system "sed -i '' 's/finite\(/isfinite(/g' src/Utility/macros.cc src/BuiltIn/floatOpSymbol.cc src/BuiltIn/floatSymbol.cc "
+    end
     ENV.deparallelize
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -15,6 +15,7 @@ class Maude < Formula
     sha256 cellar: :any, el_capitan:   "042a617f84cacfdd0d8f441fcf1209fe6bef76483b0cf848bded5dc378f82bc6"
     sha256 cellar: :any, yosemite:     "8bb72b9a8f9097656ffb4f70f7b7addb2ba2a888134af1bd96b488340d25aadc"
     sha256 cellar: :any, x86_64_linux: "e341985f51abe73a4516690daf2b5bf384286b2f48414b79108cc9933187e014"
+    sha256 cellar: :any, arm64_monterey: "0c07a7d0a31cd58e329876e605437f3ef7616d1457feda6772fa2d345a7945a0"
   end
 
   depends_on "gmp"


### PR DESCRIPTION
This allows both formulae to build on m1.

- The `tools/config.sub` script used in libbuddy is from 2003 and has absolutely no idea what to do with an m1 machine. To fix this, on ARM Macs, the system command replaces the entire script with 'echo arm-apple-darwin' to return the correct build architecture.
- maude uses the `finite()` C++ macro. The only problem with using this macro is that it is not actually part of c++; the actual macro in the C++ standard is called `isfinite()` https://www.cplusplus.com/reference/cmath/isfinite/. I have no idea why they use finite, it appears to be a BSD source thing (https://linux.die.net/man/3/finite) that is not part of the language standard; I'm surprised it even works on linux. Anyway, a quick `sed` replaces all instances of `finite()` with `isfinite()`.