### PR TITLE
Update tamarin prover formula with m1 bottle

### DIFF
--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -2,7 +2,7 @@ class TamarinProver < Formula
   desc "Automated security protocol verification tool"
   homepage "https://tamarin-prover.github.io/"
   url "https://github.com/tamarin-prover/tamarin-prover/archive/1.6.1.tar.gz"
-  sha256 "2405a94d40c59030409889af1e8490617aefdd8b3cdc1bfb55a0f75b7e590d77"
+  sha256 "d415a6076d1d05db92da821513b3883cefae00aefce323d768425bf04a5a582a"
   head "https://github.com/tamarin-prover/tamarin-prover.git", branch: "master"
 
   bottle do
@@ -10,7 +10,7 @@ class TamarinProver < Formula
     sha256 cellar: :any_skip_relocation, big_sur:      "a886014d7c2345bc2f2ea1836dd9bf1199435fcec54963f8e07e80e13fe857c6"
     sha256 cellar: :any_skip_relocation, catalina:     "b8a142ad4961d0beb06c9c4912baacca6deb7870016a22183e40dc259e60d500"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "c8fb1f445c9973a62376dd16ff711e019a00e0df3fb71d2b9afefa26fecc8ffe"
-    sha256 cellar: :any, arm64_monterey: "184712c740dbcbe97dd10213e8f0af9544881baecaae63a821bd5575e222cc05"
+    sha256 cellar: :any, arm64_monterey: "34269ddaada7f142817c4aeb38dcc223b58ff42ab719d7c0447fd0dc8da9dbd2"
   end
 
   depends_on "haskell-stack" => :build
@@ -30,7 +30,7 @@ class TamarinProver < Formula
     args = []
     #Temporary fix for GHC 9.0.2 issue, see https://gitlab.haskell.org/ghc/ghc/-/issues/20592
     if Hardware::CPU.arm? && OS.mac?
-      env["C_INCLUDE_PATH"] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ffi"
+      ENV["C_INCLUDE_PATH"] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ffi"
     end
     unless OS.mac?
       args << "--extra-include-dirs=#{Formula["zlib"].include}" << "--extra-lib-dirs=#{Formula["zlib"].lib}"

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -10,6 +10,7 @@ class TamarinProver < Formula
     sha256 cellar: :any_skip_relocation, big_sur:      "a886014d7c2345bc2f2ea1836dd9bf1199435fcec54963f8e07e80e13fe857c6"
     sha256 cellar: :any_skip_relocation, catalina:     "b8a142ad4961d0beb06c9c4912baacca6deb7870016a22183e40dc259e60d500"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "c8fb1f445c9973a62376dd16ff711e019a00e0df3fb71d2b9afefa26fecc8ffe"
+    sha256 cellar: :any, arm64_monterey: "184712c740dbcbe97dd10213e8f0af9544881baecaae63a821bd5575e222cc05"
   end
 
   depends_on "haskell-stack" => :build
@@ -27,6 +28,10 @@ class TamarinProver < Formula
     jobs = ENV.make_jobs
     system "stack", "-j#{jobs}", "setup"
     args = []
+    #Temporary fix for GHC 9.0.2 issue, see https://gitlab.haskell.org/ghc/ghc/-/issues/20592
+    if Hardware::CPU.arm? && OS.mac?
+      env["C_INCLUDE_PATH"] = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ffi"
+    end
     unless OS.mac?
       args << "--extra-include-dirs=#{Formula["zlib"].include}" << "--extra-lib-dirs=#{Formula["zlib"].lib}"
     end

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -2,7 +2,7 @@ class TamarinProver < Formula
   desc "Automated security protocol verification tool"
   homepage "https://tamarin-prover.github.io/"
   url "https://github.com/tamarin-prover/tamarin-prover/archive/1.6.1.tar.gz"
-  sha256 "d415a6076d1d05db92da821513b3883cefae00aefce323d768425bf04a5a582a"
+  sha256 "2405a94d40c59030409889af1e8490617aefdd8b3cdc1bfb55a0f75b7e590d77"
   head "https://github.com/tamarin-prover/tamarin-prover.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
This also requires the following bottle to be added to https://github.com/tamarin-prover/tamarin-prover/releases/tag/1.6.1

[tamarin-prover-1.6.1.arm64_monterey.bottle.tar.gz](https://github.com/tamarin-prover/homebrew-tap/files/8591549/tamarin-prover-1.6.1.arm64_monterey.bottle.tar.gz)

