### PR TITLE
Add linux arm64 support and bottles. 

### DIFF
--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -17,10 +17,18 @@ class Libbuddy < Formula
     if Hardware::CPU.arm? && OS.mac?
       system "echo 'echo arm-apple-darwin' > tools/config.sub"
     end
-    system "./configure", "--disable-debug",
-      "--disable-dependency-tracking",
-      "--disable-silent-rules",
-      "--prefix=#{prefix}"
+    if Hardware::CPU.arm? && OS.linux?
+      system "./configure", "--build=aarch64-unknown-linux-gnu",
+        "--disable-debug",
+        "--disable-dependency-tracking",
+        "--disable-silent-rules",
+        "--prefix=#{prefix}"
+    else
+        system "./configure", "--disable-debug",
+          "--disable-dependency-tracking",
+          "--disable-silent-rules",
+          "--prefix=#{prefix}"
+    end
     system "make", "install"
   end
 

--- a/Formula/libbuddy.rb
+++ b/Formula/libbuddy.rb
@@ -11,6 +11,7 @@ class Libbuddy < Formula
     sha256 cellar: :any_skip_relocation, catalina:     "3cab96ab2fe4506669abd447bf5185e789ab0ea2a40536ff61b0b734f167f5a0"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "0807d5706dc37213dbc466b06819fc1b93d710c3543b92eec3c07e7c4fc317d5"
     sha256 cellar: :any, arm64_monterey: "a1d72f509f29a606e8ed0ca3fa0ecbf39fcbfba0ec2375a101e23ab79f2c5162"
+    sha256 cellar: :any_skip_relocation, arm64_linux: "65348a4ae5ef5d1f2302791570d204ad307c3b731962cf96974cd64aa00bc48c"
   end
 
   def install

--- a/Formula/maude.rb
+++ b/Formula/maude.rb
@@ -9,6 +9,7 @@ class Maude < Formula
     root_url "https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies"
     sha256 cellar: :any, arm64_tahoe: "711887bd8107ad0f476d29e67f7760f6bea0724281799a13263c2428cd5f306c"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "3a941ae6e9eaa567827959dcac44129166c87b020d238c742c32467980e99936"
+    sha256 cellar: :any_skip_relocation, arm64_linux: "e9624c23c32304797a3530341cb8a7473222fb3cba621f2525c498e89a365f7c"
   end
 
   depends_on "gmp"

--- a/Formula/tamarin-prover.rb
+++ b/Formula/tamarin-prover.rb
@@ -9,6 +9,7 @@ class TamarinProver < Formula
     root_url "https://github.com/tamarin-prover/tamarin-prover/releases/download/1.12.0"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "936631c692ce9fd4c797400eff32e47d6d09e371ca251250cceac15b93f71d99"
     sha256 cellar: :any_skip_relocation, arm64_tahoe: "c4174f9f850d31243473d1bc8c04eb20117b28ec5a66276078768b58ef6ee9fd"
+    sha256 cellar: :any_skip_relocation, arm64_linux: "10d04e5689207108c9e7bd9cc42a4d431fa69886395762d2c14eb614d8da13e6"
   end
 
   depends_on "haskell-stack" => :build

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ New installs will then use this bottle.
 To build a new bottle (perhaps for a new operating system or Maude/libbuddy release):
 
 1. `brew install --build-bottle tamarin-prover/tap/maude` or `brew install --build-bottle tamarin-prover/tap/libbuddy`
-2. `brew bottle maude --keep-old --root-url=https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies` or `brew bottle lib buddy --keep-old --root-url=https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies`, and note the output it gives you with the bottle SHA and tag,
+2. `brew bottle tamarin-prover/tap/maude --keep-old --root-url=https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies` or `brew bottle tamarin-prover/tap/libbuddy --keep-old --root-url=https://raw.githubusercontent.com/tamarin-prover/binaries/HEAD/dependencies`, and note the output it gives you with the bottle SHA and tag,
 3. Rename the bottle to use a single hyphen. Homebrew should give you the relevant output on the command line to update in the `maude.rb` or `libbuddy.rb` formula. If not, on Linux, run sha256sum on the renamed file, and use the result to replace the bottle hash from previous item. On macOS, use `shasum -a 256 <filename>`.
 4. Submit a separate pull request for https://github.com/tamarin-prover/binaries/ containing the new binaries for maude or lib buddy.
 5. Update the `maude.rb` or `libbuddy.rb` formula with the bottle SHA and tag, in the bottle section.


### PR DESCRIPTION
Corresponding dependency bottles here: https://github.com/tamarin-prover/binaries/pull/6

Not sure how niche linux arm64 support is, although it's now a first class citizen for homebrew per https://docs.brew.sh/Support-Tiers#linux and is useful for running inside e.g. docker containers on MacOS, or on the qualcomm-based ARM laptops that are shipping these days.
